### PR TITLE
Add setValue to Gauge api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 target/
 
 .metals/
+.project/metals.sbt
 .bloop/
 .idea/
 

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,4 +1,0 @@
-// DO NOT EDIT! This file is auto-generated.
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.0-RC1")

--- a/src/main/scala/com/ovotech/micrometer/Reporter.scala
+++ b/src/main/scala/com/ovotech/micrometer/Reporter.scala
@@ -52,6 +52,9 @@ object Reporter {
 
     /** Run `action` with the gauge incremented before execution and decremented after termination (including error or cancelation) */
     def surround[A](action: F[A]): F[A]
+
+    /** Sets the gauge's value to `n` */
+    def setValue(n: Int): F[Unit]
   }
 
   def fromRegistry[F[_]](
@@ -140,9 +143,7 @@ object Reporter {
           micrometer.Gauge
             .builder(
               pname,
-              created, { x: AtomicInteger =>
-                x.doubleValue
-              }
+              created, { x: AtomicInteger => x.doubleValue }
             )
             .tags(allTags)
             .register(mx)
@@ -164,6 +165,8 @@ object Reporter {
 
               def surround[A](action: F[A]): F[A] =
                 increment.bracket(_ => action)(_ => decrement)
+
+              def setValue(n: Int): F[Unit] = F.delay(g.set(n))
             }
           }
       }


### PR DESCRIPTION
This is an operation that we can support and that's generally expected to exist. Downstream users can't effectively add it, because Reporter is invariant in `F`, so subclassing Gauge doesn't help much.