### PR TITLE
Remove the non-used release plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,9 @@
-import sbtrelease.ExtraReleaseCommands
-import sbtrelease.ReleaseStateTransformations._
-import sbtrelease.tagsonly.TagsOnly._
-
 lazy val http4sVersion = "0.21.23"
 lazy val micrometerVersion = "1.7.0"
 lazy val catsEffectVersion = "2.5.1"
 lazy val scalaTestVersion = "3.2.9"
+
+Global / excludeLintKeys += Compile / console / scalacOptions
 
 lazy val publicArtifactory = "Artifactory Realm" at "https://kaluza.jfrog.io/artifactory/maven"
 
@@ -16,16 +14,7 @@ lazy val publishSettings = Seq(
       usr <- sys.env.get("ARTIFACTORY_USER")
       password <- sys.env.get("ARTIFACTORY_PASS")
     } yield Credentials("Artifactory Realm", "kaluza.jfrog.io", usr, password)
-  }.getOrElse(Credentials(Path.userHome / ".ivy2" / ".credentials")),
-  releaseProcess := Seq[ReleaseStep](
-    checkSnapshotDependencies,
-    releaseStepCommand(ExtraReleaseCommands.initialVcsChecksCommand),
-    setVersionFromTags(releaseTagPrefix.value),
-    runClean,
-    tagRelease,
-    publishArtifacts,
-    pushTagsOnly
-  )
+  }.getOrElse(Credentials(Path.userHome / ".ivy2" / ".credentials"))
 )
 
 lazy val `http4s-micrometer-metrics` = (project in file("."))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.13")
-addSbtPlugin("fr.qux" % "sbt-release-tags-only" % "0.5.0")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.17")


### PR DESCRIPTION
The `sbt-release-tags-only` is not used because this library is published using the `sbt +publish` command rather than `sbt release`.

Bump up other plugin versions